### PR TITLE
mainImageWrapper -- function to customise image element

### DIFF
--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -876,17 +876,21 @@ class ReactImageLightbox extends Component {
                     </div>
                 );
             } else {
-                images.push(
-                    <img
-                        className={`${imageClass} ${styles.image}`}
-                        onDoubleClick={this.handleImageDoubleClick}
-                        onWheel={this.handleImageMouseWheel}
-                        style={imageStyle}
-                        src={imageSrc}
-                        key={imageSrc + keyEndings[srcType]}
-                        alt={this.props.imageTitle || translate('Image')}
-                    />
-                );
+                let image = (<img
+                    className={`${imageClass} ${styles.image}`}
+                    onDoubleClick={this.handleImageDoubleClick}
+                    onWheel={this.handleImageMouseWheel}
+                    style={imageStyle}
+                    src={imageSrc}
+                    key={imageSrc + keyEndings[srcType]}
+                    alt={this.props.imageTitle || translate('Image')}
+                />);
+
+                if (this.props.mainImageWrapper) {
+                    image = this.props.mainImageWrapper(image);
+                }
+
+                images.push(image);
             }
         };
 
@@ -1080,6 +1084,9 @@ ReactImageLightbox.propTypes = {
 
     // Main display image url
     mainSrc: PropTypes.string.isRequired,
+
+    // Main display image's wrapper
+    mainImageWrapper: PropTypes.func,
 
     // Previous display image url (displayed to the left)
     // If left undefined, movePrev actions will not be performed, and the button not displayed


### PR DESCRIPTION
Maybe this can be done better. Let me know.

The story behind this is that in my project I need to display a custom element right under the image. Since image is absolutely positioned and takes all the available space, I had to clone the image element and set new CSS styles:

```
<Lightbox
          mainSrc={lightboxSessionImage.image.url}
          onCloseRequest={this.closeLightbox}
          mainImageWrapper={image => {
            console.log(lightboxSessionImage)

            const exifTags = lightboxSessionImage.image.exif.tags

            if (exifTags) {
              const takenAt = moment.unix(exifTags.DateTimeOriginal - 10 * 60 * 60)
              const timeAgoInWords = moment.duration(moment().diff(takenAt)).humanize()

              var takenAtDateTime = `Taken ${timeAgoInWords} ago`

              const latitude = exifTags.GPSLatitude
              const longitude = exifTags.GPSLongitude

              var takenAtElement = <div>
                Taken at{ " " }
                <a href={"http://www.google.com/maps/place/" + latitude + ',' + longitude} target="_blank">{lightboxSessionImageLocation}</a>
              </div>
            } else {
              var takenAtDateTime = "Taken date time: ?"
              var takenAtElement = "Taken at: ?"
            }

            return(
              <div>
                {React.cloneElement(image, Object.assign(image.props.style, { bottom: '100px' }))}

                <div className="image-info-box">
                  <div>
                    { takenAtDateTime }
                  </div>
                  <div>
                    { takenAtElement }
                  </div>
                </div>
              </div>
            )
          }}
        />
```
