### PR TITLE
Add hideToolbarButtons prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ imageTitle          | node   |                |          | Image title (Descript
 imageCaption        | node   |                |          | Image caption (Descriptive element below image)
 imageCrossOrigin    | string |                |          | `crossorigin` attribute to append to `img` elements ([MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-crossorigin))
 toolbarButtons      | node[] |                |          | Array of custom toolbar buttons
+hideToolbarButtons  | bool   | `false`        |          | When `true`, hide all default toolbars buttons (close, zoom in, zoom out), useful when override default buttons with custom defined toolbarButtons
 reactModalStyle     | Object | `{}`           |          | Set `z-index` style, etc., for the parent react-modal ([react-modal style format](https://github.com/reactjs/react-modal#styles))
 reactModalProps     | Object | `{}`           |          | Override props set on react-modal (https://github.com/reactjs/react-modal)
 imagePadding        | number | `10`           |          | Padding (px) between the edge of the window and the lightbox

--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -1294,6 +1294,7 @@ class ReactImageLightbox extends Component {
       onAfterOpen,
       imageCrossOrigin,
       reactModalProps,
+      hideToolbarButtons,
     } = this.props;
     const {
       zoomLevel,
@@ -1581,74 +1582,80 @@ class ReactImageLightbox extends Component {
                   </li>
                 ))}
 
-              {enableZoom && (
+              {!hideToolbarButtons &&
+                enableZoom && (
+                  <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
+                    <button // Lightbox zoom in button
+                      type="button"
+                      key="zoom-in"
+                      aria-label={this.props.zoomInLabel}
+                      className={[
+                        'ril-zoom-in',
+                        styles.toolbarItemChild,
+                        styles.builtinButton,
+                        styles.zoomInButton,
+                        ...(zoomLevel === MAX_ZOOM_LEVEL
+                          ? [styles.builtinButtonDisabled]
+                          : []),
+                      ].join(' ')}
+                      disabled={
+                        this.isAnimating() || zoomLevel === MAX_ZOOM_LEVEL
+                      }
+                      onClick={
+                        !this.isAnimating() && zoomLevel !== MAX_ZOOM_LEVEL
+                          ? this.handleZoomInButtonClick
+                          : undefined
+                      }
+                    />
+                  </li>
+                )}
+
+              {!hideToolbarButtons &&
+                enableZoom && (
+                  <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
+                    <button // Lightbox zoom out button
+                      type="button"
+                      key="zoom-out"
+                      aria-label={this.props.zoomOutLabel}
+                      className={[
+                        'ril-zoom-out',
+                        styles.toolbarItemChild,
+                        styles.builtinButton,
+                        styles.zoomOutButton,
+                        ...(zoomLevel === MIN_ZOOM_LEVEL
+                          ? [styles.builtinButtonDisabled]
+                          : []),
+                      ].join(' ')}
+                      disabled={
+                        this.isAnimating() || zoomLevel === MIN_ZOOM_LEVEL
+                      }
+                      onClick={
+                        !this.isAnimating() && zoomLevel !== MIN_ZOOM_LEVEL
+                          ? this.handleZoomOutButtonClick
+                          : undefined
+                      }
+                    />
+                  </li>
+                )}
+
+              {!hideToolbarButtons && (
                 <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
-                  <button // Lightbox zoom in button
+                  <button // Lightbox close button
                     type="button"
-                    key="zoom-in"
-                    aria-label={this.props.zoomInLabel}
-                    className={[
-                      'ril-zoom-in',
-                      styles.toolbarItemChild,
-                      styles.builtinButton,
-                      styles.zoomInButton,
-                      ...(zoomLevel === MAX_ZOOM_LEVEL
-                        ? [styles.builtinButtonDisabled]
-                        : []),
-                    ].join(' ')}
-                    disabled={
-                      this.isAnimating() || zoomLevel === MAX_ZOOM_LEVEL
+                    key="close"
+                    aria-label={this.props.closeLabel}
+                    className={
+                      'ril-close ril-toolbar__item__child' +
+                      ` ${styles.toolbarItemChild} ${styles.builtinButton} ${
+                        styles.closeButton
+                      }`
                     }
                     onClick={
-                      !this.isAnimating() && zoomLevel !== MAX_ZOOM_LEVEL
-                        ? this.handleZoomInButtonClick
-                        : undefined
-                    }
+                      !this.isAnimating() ? this.requestClose : undefined
+                    } // Ignore clicks during animation
                   />
                 </li>
               )}
-
-              {enableZoom && (
-                <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
-                  <button // Lightbox zoom out button
-                    type="button"
-                    key="zoom-out"
-                    aria-label={this.props.zoomOutLabel}
-                    className={[
-                      'ril-zoom-out',
-                      styles.toolbarItemChild,
-                      styles.builtinButton,
-                      styles.zoomOutButton,
-                      ...(zoomLevel === MIN_ZOOM_LEVEL
-                        ? [styles.builtinButtonDisabled]
-                        : []),
-                    ].join(' ')}
-                    disabled={
-                      this.isAnimating() || zoomLevel === MIN_ZOOM_LEVEL
-                    }
-                    onClick={
-                      !this.isAnimating() && zoomLevel !== MIN_ZOOM_LEVEL
-                        ? this.handleZoomOutButtonClick
-                        : undefined
-                    }
-                  />
-                </li>
-              )}
-
-              <li className={`ril-toolbar__item ${styles.toolbarItem}`}>
-                <button // Lightbox close button
-                  type="button"
-                  key="close"
-                  aria-label={this.props.closeLabel}
-                  className={
-                    'ril-close ril-toolbar__item__child' +
-                    ` ${styles.toolbarItemChild} ${styles.builtinButton} ${
-                      styles.closeButton
-                    }`
-                  }
-                  onClick={!this.isAnimating() ? this.requestClose : undefined} // Ignore clicks during animation
-                />
-              </li>
             </ul>
           </div>
 
@@ -1794,6 +1801,9 @@ ReactImageLightbox.propTypes = {
   // Array of custom toolbar buttons
   toolbarButtons: PropTypes.arrayOf(PropTypes.node),
 
+  // When true, hide all default toolbars buttons (close, zoom in, zoom out), useful when override default buttons with custom defined toolbarButtons
+  hideToolbarButtons: PropTypes.bool,
+
   // When true, clicks outside of the image close the lightbox
   clickOutsideToClose: PropTypes.bool,
 
@@ -1829,6 +1839,7 @@ ReactImageLightbox.defaultProps = {
   imageCrossOrigin: null,
   keyRepeatKeyupBonus: 40,
   keyRepeatLimit: 180,
+  hideToolbarButtons: false,
   mainSrcThumbnail: null,
   nextLabel: 'Next image',
   nextSrc: null,


### PR DESCRIPTION
**This prop helps with toolbar customization**

When true, hide all default toolbars buttons (close, zoom in, zoom out), useful when override default buttons with custom defined toolbarButtons

I need this, because in my project i override default close button with material-ui button with tooltip

![screen shot 2018-03-29 at 11 09 41](https://user-images.githubusercontent.com/10739349/38080453-cbc272aa-3341-11e8-81ba-bacad460f469.png)
