### PR TITLE
Add workaround for umd build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,8 @@ const config = {
   output: {
     path: __dirname,
     filename: '[name].js',
+    // See https://github.com/webpack/webpack/issues/6522
+    globalObject: 'typeof self !== \'undefined\' ? self : this',
     libraryTarget: 'umd',
     library: 'ReactImageLightbox',
   },


### PR DESCRIPTION
Prevents webpack from referencing window which was causing an error in SSR.

Fixes #118