### PR TITLE
Fix Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,8 +20,8 @@ export interface ILightBoxProps {
     animationDuration?: number;
     keyRepeatLimit?: number;
     keyRepeatKeyupBonus?: number;
-    imageTitle?: string;
-    imageCaption?: string;
+    imageTitle?: React.ReactNode | string;
+    imageCaption?: React.ReactNode | string;
     imageCrossOrigin?: string;
     toolbarButtons?: React.ReactNode[];
     reactModalStyle?: any;


### PR DESCRIPTION
The lightbox accepts ReactNode elements for `imageTitle` and `imageCaption`, as is documented in https://github.com/frontend-collective/react-image-lightbox#options

The current `index.d.ts` however only allows strings for these attributes. This pull request adds `React.ReactNode` as possible types.