### PR TITLE
Fix-preventDefault

### DIFF
--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -608,7 +608,6 @@ class ReactImageLightbox extends Component {
    */
   handleOuterMousewheel(event) {
     // Prevent scrolling of the background
-    event.preventDefault();
     event.stopPropagation();
 
     const xThreshold = WHEEL_MOVE_X_THRESHOLD;
@@ -658,7 +657,6 @@ class ReactImageLightbox extends Component {
   }
 
   handleImageMouseWheel(event) {
-    event.preventDefault();
     const yThreshold = WHEEL_MOVE_Y_THRESHOLD;
 
     if (Math.abs(event.deltaY) >= Math.abs(event.deltaX)) {


### PR DESCRIPTION
Fix #171 

[Intervention] Unable to preventDefault inside passive event listener due to target being treated as passive. See 
template_c9d5c027add377a282dfce7e8258eb0d.js?1550317005559734:1826 [Intervention] Unable to preventDefault inside passive event listener due to target being treated as passive. See https://www.chromestatus.com/features/5093566007214080

We cannot call **preventDefault** inside passive event listener
More info on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)