### PR TITLE
Fix cross origin iframe detection

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -33,11 +33,20 @@ export function getHighestSafeWindowContext(self = global.window.self) {
     return self;
   }
 
-  const getOrigin = href => href.match(/(.*\/\/.*?)(\/|$)/)[1];
+  const isCrossOriginFrame = () => {
+    try {
+      return (
+        global.document.location.hostname !==
+        global.window.parent.location.hostname
+      );
+    } catch (e) {
+      return true;
+    }
+  };
 
   // If parent is the same origin, we can move up one context
   // Reference: https://stackoverflow.com/a/21965342/1601953
-  if (getOrigin(self.location.href) === getOrigin(referrer)) {
+  if (!isCrossOriginFrame()) {
     return getHighestSafeWindowContext(self.parent);
   }
 


### PR DESCRIPTION
Fixes https://github.com/frontend-collective/react-image-lightbox/issues/151

`getHighestSafeWindowContext` is broken in the use case described in the issue due to an invalid way of detecting cross-origin framing. This PR just replaces the cross-origin detection with the approach suggested by [this SO comment](https://stackoverflow.com/a/42660748). This appears to work fine in my use case.