### PR TITLE
chore: bump peer dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "react-modal": "^3.11.1"
   },
   "peerDependencies": {
-    "react": "^16.x",
-    "react-dom": "^16.x"
+    "react": "^16.x < 17",
+    "react-dom": "^16.x < 17"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",


### PR DESCRIPTION
Resolve NPM install error in projects using React 17 and NPM 7

```
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```