### PR TITLE
onChangeZoom extracted to capture zoom in and out event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ export interface ILightBoxProps {
     onMoveNextRequest?(): void;
     onImageLoad?(): void;
     onImageLoadError?(): void;
+    onChangeZoom?(zoomLevel:number): void;
     imageLoadErrorMessage?: React.ReactNode;
     onAfterOpen?(): void;
     discourageDownloads?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image-lightbox",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "A lightbox component for React.js",
   "scripts": {
     "build": "rollup -c",

--- a/src/__tests__/__snapshots__/react-image-lightbox.spec.js.snap
+++ b/src/__tests__/__snapshots__/react-image-lightbox.spec.js.snap
@@ -22,6 +22,7 @@ exports[`Snapshot Testing Lightbox renders properly" 1`] = `
   nextSrc={null}
   nextSrcThumbnail={null}
   onAfterOpen={[Function]}
+  onChangeZoom={[Function]}
   onCloseRequest={[Function]}
   onImageLoad={[Function]}
   onImageLoadError={[Function]}

--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -530,6 +530,7 @@ class ReactImageLightbox extends Component {
       offsetX: nextOffsetX,
       offsetY: nextOffsetY,
     });
+    this.onChangeZoom(zoomLevel);
   }
 
   closeIfClickInner(event) {
@@ -1683,6 +1684,9 @@ ReactImageLightbox.propTypes = {
   // Called when image successfully loads
   onImageLoad: PropTypes.func,
 
+  // Called when image zoomed in or out
+  onChangeZoom: PropTypes.func,
+
   // Open window event
   onAfterOpen: PropTypes.func,
 
@@ -1795,6 +1799,7 @@ ReactImageLightbox.defaultProps = {
   onAfterOpen: () => {},
   onImageLoadError: () => {},
   onImageLoad: () => {},
+  onChangeZoom:() => {},
   onMoveNextRequest: () => {},
   onMovePrevRequest: () => {},
   prevLabel: 'Previous image',


### PR DESCRIPTION
The onChangeZoom is necessary to provide a URL to get a smaller image for the base case when the picture is not zoomed.