### PR TITLE
Add React 18 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "react-modal": "^3.11.1"
   },
   "peerDependencies": {
-    "react": "16.x || 17.x",
-    "react-dom": "16.x || 17.x"
+    "react": "16.x || 17.x || 18.x",
+    "react-dom": "16.x || 17.x || 18.x"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.4",


### PR DESCRIPTION
This PR adds React 18 to the list of allowed peer dependencies.