### PR TITLE
feat: allow zoom on single click

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,40 +1,41 @@
 import * as React from 'react';
 
 export interface ILightBoxProps {
-    mainSrc: string;
-    nextSrc?: string;
-    prevSrc?: string;
-    mainSrcThumbnail?: string;
-    prevSrcThumbnail?: string;
-    nextSrcThumbnail?: string;
-    onCloseRequest(): void;
-    onMovePrevRequest?(): void;
-    onMoveNextRequest?(): void;
-    onImageLoad?(): void;
-    onImageLoadError?(): void;
-    imageLoadErrorMessage?: React.ReactNode;
-    onAfterOpen?(): void;
-    discourageDownloads?: boolean;
-    animationDisabled?: boolean;
-    animationOnKeyInput?: boolean;
-    animationDuration?: number;
-    keyRepeatLimit?: number;
-    keyRepeatKeyupBonus?: number;
-    imageTitle?: React.ReactNode | string;
-    imageCaption?: React.ReactNode | string;
-    imageCrossOrigin?: string;
-    toolbarButtons?: React.ReactNode[];
-    reactModalStyle?: any;
-    reactModalProps?: any;
-    imagePadding?: number;
-    clickOutsideToClose?: boolean;
-    enableZoom?: boolean;
-    wrapperClassName?: string;
-    nextLabel?: string;
-    prevLabel?: string;
-    zoomInLabel?: string;
-    zoomOutLabel?: string;
-    closeLabel?: string;
+  mainSrc: string;
+  nextSrc?: string;
+  prevSrc?: string;
+  mainSrcThumbnail?: string;
+  prevSrcThumbnail?: string;
+  nextSrcThumbnail?: string;
+  onCloseRequest(): void;
+  onMovePrevRequest?(): void;
+  onMoveNextRequest?(): void;
+  onImageLoad?(): void;
+  onImageLoadError?(): void;
+  imageLoadErrorMessage?: React.ReactNode;
+  onAfterOpen?(): void;
+  discourageDownloads?: boolean;
+  animationDisabled?: boolean;
+  animationOnKeyInput?: boolean;
+  animationDuration?: number;
+  keyRepeatLimit?: number;
+  keyRepeatKeyupBonus?: number;
+  imageTitle?: React.ReactNode | string;
+  imageCaption?: React.ReactNode | string;
+  imageCrossOrigin?: string;
+  toolbarButtons?: React.ReactNode[];
+  reactModalStyle?: any;
+  reactModalProps?: any;
+  imagePadding?: number;
+  clickOutsideToClose?: boolean;
+  enableZoom?: boolean;
+  wrapperClassName?: string;
+  nextLabel?: string;
+  prevLabel?: string;
+  zoomInLabel?: string;
+  zoomOutLabel?: string;
+  closeLabel?: string;
+  zoomOnClick?: boolean;
 }
 
-export default class Lightbox extends React.Component<ILightBoxProps, never> { }
+export default class Lightbox extends React.Component<ILightBoxProps, never> {}

--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -105,6 +105,8 @@ class ReactImageLightbox extends Component {
 
       // image load error for srcType
       loadErrorStatus: {},
+
+      dragging: false,
     };
 
     // Refs
@@ -114,6 +116,7 @@ class ReactImageLightbox extends Component {
     this.caption = React.createRef();
 
     this.closeIfClickInner = this.closeIfClickInner.bind(this);
+    this.handleImageClick = this.handleImageClick.bind(this);
     this.handleImageDoubleClick = this.handleImageDoubleClick.bind(this);
     this.handleImageMouseWheel = this.handleImageMouseWheel.bind(this);
     this.handleKeyInput = this.handleKeyInput.bind(this);
@@ -696,6 +699,16 @@ class ReactImageLightbox extends Component {
     }
   }
 
+  /**
+   * Handle a click on the current image
+   */
+  handleImageClick(event) {
+    if (!this.props.zoomOnClick) return;
+    if (this.state.dragging) return;
+
+    this.handleImageDoubleClick(event);
+  }
+
   shouldHandleEvent(source) {
     if (this.eventsSource === source) {
       return true;
@@ -738,6 +751,8 @@ class ReactImageLightbox extends Component {
   }
 
   handleMouseDown(event) {
+    this.setState({ dragging: false });
+
     if (
       this.shouldHandleEvent(SOURCE_MOUSE) &&
       ReactImageLightbox.isTargetMatchImage(event.target)
@@ -748,6 +763,8 @@ class ReactImageLightbox extends Component {
   }
 
   handleMouseMove(event) {
+    this.setState({ dragging: true });
+
     if (this.shouldHandleEvent(SOURCE_MOUSE)) {
       this.multiPointerMove(event, [ReactImageLightbox.parseMouseEvent(event)]);
     }
@@ -764,12 +781,16 @@ class ReactImageLightbox extends Component {
     if (this.shouldHandleEvent(SOURCE_POINTER)) {
       switch (event.type) {
         case 'pointerdown':
+          this.setState({ dragging: false });
+
           if (ReactImageLightbox.isTargetMatchImage(event.target)) {
             this.addPointer(ReactImageLightbox.parsePointerEvent(event));
             this.multiPointerStart(event);
           }
           break;
         case 'pointermove':
+          this.setState({ dragging: true });
+
           this.multiPointerMove(event, [
             ReactImageLightbox.parsePointerEvent(event),
           ]);
@@ -1395,6 +1416,7 @@ class ReactImageLightbox extends Component {
           <img
             {...(imageCrossOrigin ? { crossOrigin: imageCrossOrigin } : {})}
             className={`${imageClass} ril__image`}
+            onClick={this.handleImageClick}
             onDoubleClick={this.handleImageDoubleClick}
             onWheel={this.handleImageMouseWheel}
             onDragStart={e => e.preventDefault()}


### PR DESCRIPTION
We use the library in our project and it works very well, thanks for that!

This PR adds another prop `zoomOnClick` that allows single click zoom as implemented in other lightboxes. Since we still want to allow drags to change the viewport when zoomed in it saves the "dragging" state in the component state.

I will still need to add the appropriate tests, update the README.md and bump the minor version.

Just wanted to test the waters if that is something you would consider merging?