### PR TITLE
Use globalThis instead of global

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,5 +10,8 @@
     "react/jsx-props-no-spreading": 0,
     "react/prop-types": 0,
     "react/sort-comp": 0
+  },
+  "globals": {
+    "globalThis": false
   }
 }

--- a/src/__tests__/react-image-lightbox.spec.js
+++ b/src/__tests__/react-image-lightbox.spec.js
@@ -313,7 +313,7 @@ describe('Utils', () => {
       location: { href: 'http://test.test' },
       document: { referrer: 'http://test.test' },
     };
-    expect(getHighestSafeWindowContext(self)).toBe(global.window.top);
+    expect(getHighestSafeWindowContext(self)).toBe(globalThis.window.top);
   });
   it.skip('getHighestSafeWindowContext function if parent is a different origin', () => {
     const self = {

--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -1461,8 +1461,8 @@ class ReactImageLightbox extends Component {
         style={modalStyle}
         contentLabel={translate('Lightbox')}
         appElement={
-          typeof global.window !== 'undefined'
-            ? global.window.document.body
+          typeof globalThis.window !== 'undefined'
+            ? globalThis.window.document.body
             : undefined
         }
         {...reactModalProps}

--- a/src/util.js
+++ b/src/util.js
@@ -17,17 +17,22 @@ export function translate(str, replaceStrings = null) {
 }
 
 export function getWindowWidth() {
-  return typeof global.window !== 'undefined' ? global.window.innerWidth : 0;
+  return typeof globalThis.window !== 'undefined'
+    ? globalThis.window.innerWidth
+    : 0;
 }
 
 export function getWindowHeight() {
-  return typeof global.window !== 'undefined' ? global.window.innerHeight : 0;
+  return typeof globalThis.window !== 'undefined'
+    ? globalThis.window.innerHeight
+    : 0;
 }
 
 const isCrossOriginFrame = () => {
   try {
     return (
-      global.window.location.hostname !== global.window.parent.location.hostname
+      globalThis.window.location.hostname !==
+      globalThis.window.parent.location.hostname
     );
   } catch (e) {
     return true;
@@ -36,7 +41,7 @@ const isCrossOriginFrame = () => {
 
 // Get the highest window context that isn't cross-origin
 // (When in an iframe)
-export function getHighestSafeWindowContext(self = global.window.self) {
+export function getHighestSafeWindowContext(self = globalThis.window.self) {
   // If we reached the top level, return self
   if (self === global.window.top) {
     return self;


### PR DESCRIPTION
When using esm-based CDN's. The `global` object is throwing an error. Because it should e accessed either 
`globalThis` or `window`.

Some CDN's like `skypack` which uses rollup internally adds polyfills for the usage and reassigns the `global` with `window` or an empty object like this

### Skypack

https://cdn.skypack.dev/-/react-image-lightbox@v5.1.4-RywgOQisSXB8YA3RX6o3/dist=es2019,mode=imports/optimized/react-image-lightbox.js

```js
var global$1 = typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {};
```

But when using from `jspm` this polyfill doesn't happen. And so when used throws an error. As a workaround users can add
```html
<script type="text/javascript">
    var global = globalThis
</script>
```

So, just adding PR to change the usage of `global` to `globalThis`

Steps to reproduce
- Visit this codepen and open your console for the error
https://codepen.io/jkrishna/pen/abqXxNR?editors=1111