### PR TITLE
fix: conditional rendering causes issues in React 16.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,24 +51,23 @@ export default class LightboxExample extends Component {
           Open Lightbox
         </button>
 
-        {isOpen && (
-          <Lightbox
-            mainSrc={images[photoIndex]}
-            nextSrc={images[(photoIndex + 1) % images.length]}
-            prevSrc={images[(photoIndex + images.length - 1) % images.length]}
-            onCloseRequest={() => this.setState({ isOpen: false })}
-            onMovePrevRequest={() =>
-              this.setState({
-                photoIndex: (photoIndex + images.length - 1) % images.length,
-              })
-            }
-            onMoveNextRequest={() =>
-              this.setState({
-                photoIndex: (photoIndex + 1) % images.length,
-              })
-            }
-          />
-        )}
+        <Lightbox
+          isOpen={isOpen}
+          mainSrc={images[photoIndex]}
+          nextSrc={images[(photoIndex + 1) % images.length]}
+          prevSrc={images[(photoIndex + images.length - 1) % images.length]}
+          onCloseRequest={() => this.setState({ isOpen: false })}
+          onMovePrevRequest={() =>
+            this.setState({
+              photoIndex: (photoIndex + images.length - 1) % images.length,
+            })
+          }
+          onMoveNextRequest={() =>
+            this.setState({
+              photoIndex: (photoIndex + 1) % images.length,
+            })
+          }
+        />
       </div>
     );
   }

--- a/examples/cats/app.js
+++ b/examples/cats/app.js
@@ -132,29 +132,25 @@ class App extends Component {
   }
 
   render() {
-    let lightbox;
-    if (this.state.isOpen) {
-      lightbox = (
-        <Lightbox
-          mainSrc={images[this.state.index]}
-          nextSrc={images[(this.state.index + 1) % images.length]}
-          prevSrc={
-            images[(this.state.index + images.length - 1) % images.length]
-          }
-          mainSrcThumbnail={thumbs[this.state.index]}
-          nextSrcThumbnail={thumbs[(this.state.index + 1) % images.length]}
-          prevSrcThumbnail={
-            thumbs[(this.state.index + images.length - 1) % images.length]
-          }
-          onCloseRequest={this.closeLightbox}
-          onMovePrevRequest={this.movePrev}
-          onMoveNextRequest={this.moveNext}
-          onImageLoadError={App.onImageLoadError}
-          imageTitle={titles[this.state.index]}
-          imageCaption={captions[this.state.index]}
-        />
-      );
-    }
+    let lightbox = (
+      <Lightbox
+        isOpen={this.state.isOpen}
+        mainSrc={images[this.state.index]}
+        nextSrc={images[(this.state.index + 1) % images.length]}
+        prevSrc={images[(this.state.index + images.length - 1) % images.length]}
+        mainSrcThumbnail={thumbs[this.state.index]}
+        nextSrcThumbnail={thumbs[(this.state.index + 1) % images.length]}
+        prevSrcThumbnail={
+          thumbs[(this.state.index + images.length - 1) % images.length]
+        }
+        onCloseRequest={this.closeLightbox}
+        onMovePrevRequest={this.movePrev}
+        onMoveNextRequest={this.moveNext}
+        onImageLoadError={App.onImageLoadError}
+        imageTitle={titles[this.state.index]}
+        imageCaption={captions[this.state.index]}
+      />
+    );
 
     return (
       <div>

--- a/src/__tests__/__snapshots__/react-image-lightbox.spec.js.snap
+++ b/src/__tests__/__snapshots__/react-image-lightbox.spec.js.snap
@@ -14,6 +14,7 @@ exports[`Snapshot Testing Lightbox renders properly" 1`] = `
   imageLoadErrorMessage="This image failed to load"
   imagePadding={10}
   imageTitle={null}
+  isOpen={true}
   keyRepeatKeyupBonus={40}
   keyRepeatLimit={180}
   mainSrc="/fake/image/src.jpg"

--- a/src/__tests__/react-image-lightbox.spec.js
+++ b/src/__tests__/react-image-lightbox.spec.js
@@ -15,6 +15,7 @@ Lightbox.loadStyles = jest.fn();
 
 const commonProps = {
   mainSrc: '/fake/image/src.jpg',
+  isOpen: true,
   onCloseRequest: () => {},
 };
 

--- a/src/react-image-lightbox.js
+++ b/src/react-image-lightbox.js
@@ -1279,6 +1279,7 @@ class ReactImageLightbox extends Component {
       imageCrossOrigin,
       reactModalProps,
       loader,
+      isOpen,
     } = this.props;
     const {
       zoomLevel,
@@ -1448,7 +1449,7 @@ class ReactImageLightbox extends Component {
 
     return (
       <Modal
-        isOpen
+        isOpen={isOpen}
         onRequestClose={clickOutsideToClose ? this.requestClose : undefined}
         onAfterOpen={() => {
           // Focus on the div with key handlers


### PR DESCRIPTION
Removes conditional rendering in favor of passing down the `isOpen`
property to the React `<Modal>` component.

In more recent versions of React, conditional rendering through the use
of portals creates an issue that appears (from my anecdotal experience)
related to #589 ("Loading icon gets stuck..."). Tracking this down in
the React Modal issue tracker, led me to: https://github.com/reactjs/react-modal/issues/808
    
... in which the following statement was made:

> It's recommended to not use modal with conditional rendering. There
> is a problem with createPortal when using this way (need to check if
> it still happening. It starts happening on version +16.3 of react).
>
> Are you all using conditional rendering?

Since `react-modal` recommends against using conditional rendering,
I'm submitting a patch that should hopefully complement other fixes for
#589 and also bring the usage of the `<Modal />` in this project closer
to what is recommended by the upstream project maintainers.